### PR TITLE
Add htaccess rewrite for PHP files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+
+# Use existing directories or files
+RewriteCond %{REQUEST_FILENAME} -d [OR]
+RewriteCond %{REQUEST_FILENAME} -f
+RewriteRule ^ - [L]
+
+# Automatically add .php extension if a matching file exists
+RewriteCond %{REQUEST_FILENAME}.php -f
+RewriteRule ^(.+)$ $1.php [L,QSA]


### PR DESCRIPTION
## Summary
- add `.htaccess` with rewrite rules to automatically serve PHP files without requiring the `.php` extension

## Testing
- ❌ `php -l config.php` *(failed: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ab9935e08832886b32bc3a1909733